### PR TITLE
Fix using requirements.txt

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,17 @@
 python_requirements(
     name="requirements",
-    source="requirements.txt"
+    source="requirements.txt",
+    overrides={
+        "numpy": {
+            "requirements": [
+                "numpy >=1.16.2; python_version == '3.7'",
+                "numpy >=1.21.3,<1.22.0; python_version == '3.10'",
+            ],
+            "modules": ["numpy"],
+        }
+    },
 )
 
 python_tests(
     name="tests",
-    dependencies=[":requirements"]
 )


### PR DESCRIPTION
This fix is a bit silly in this example since the requirements.txt only contains the numpy pair and this is completely over-ridden. This style would start to make sense when requirements.txt has 10s of entries and just one or two is over-ridden though.