### PR TITLE
This fix is the equivalent of method1.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,12 @@
-python_requirements(
-    name="requirements",
-    source="requirements.txt"
+python_requirement(
+    name="numpy",
+    requirements=[
+        "numpy >=1.16.2; python_version == '3.7'",
+        "numpy >=1.21.3,<1.22.0; python_version == '3.10'",
+    ],
+    modules=["numpy"],
 )
 
 python_tests(
     name="tests",
-    dependencies=[":requirements"]
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-numpy >=1.16.2; python_version == '3.7'
-numpy >=1.21.3,<1.22.0; python_version == '3.10'


### PR DESCRIPTION
This is almost what the method1 `python_requirements` target generator actually generates behind the scenes, 1 `python_requirement` target per requirements.txt line. Both method1 and this method2 combine 2 requirements (requirement.txt lines) into 1 `python_requirement` target. This is needed because dependency inference is performed based on the `modules` field and `python_requirements` naively sees two independent providers of the `numpy` module and throws it's hands up due to ambiguity. By combining the requirements here, there is no ambiguity - there is a single source for the `numpy` module to be inferred from now.